### PR TITLE
Update form rendering to Bootstrap 5

### DIFF
--- a/example/templates/app/form_inline.html
+++ b/example/templates/app/form_inline.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 
-    <form role="form" class="form-inline" method="post">
+    <form role="form" class="row" method="post">
         {% csrf_token %}
         {% bootstrap_form form layout='inline' %}
         {% buttons submit='OK' reset='Cancel' layout='inline' %}{% endbuttons %}

--- a/src/bootstrap5/forms.py
+++ b/src/bootstrap5/forms.py
@@ -39,7 +39,7 @@ def render_field(field, **kwargs):
     return renderer_cls(field, **kwargs).render()
 
 
-def render_label(content, label_for=None, label_class=None, label_title=""):
+def render_label(content, label_for=None, label_class="form-label", label_title=""):
     """Render a label with content."""
     attrs = {}
     if label_for:

--- a/src/bootstrap5/forms.py
+++ b/src/bootstrap5/forms.py
@@ -6,7 +6,7 @@ from .exceptions import BootstrapError
 from .text import text_value
 from .utils import add_css_class, render_tag
 
-FORM_GROUP_CLASS = "form-group"
+FORM_GROUP_CLASS = "mb-3"
 
 
 def render_formset(formset, **kwargs):

--- a/src/bootstrap5/renderers.py
+++ b/src/bootstrap5/renderers.py
@@ -207,7 +207,7 @@ class FieldRenderer(BaseRenderer):
     """Default field renderer."""
 
     # These widgets will not be wrapped in a form-control class
-    WIDGETS_NO_FORM_CONTROL = (CheckboxInput, RadioSelect, CheckboxSelectMultiple, FileInput)
+    WIDGETS_NO_FORM_CONTROL = (CheckboxInput, RadioSelect, CheckboxSelectMultiple, Select)
 
     def __init__(self, field, *args, **kwargs):
         if not isinstance(field, BoundField):
@@ -283,8 +283,8 @@ class FieldRenderer(BaseRenderer):
             classes = add_css_class(classes, self.get_size_class())
         elif isinstance(widget, CheckboxInput):
             classes = add_css_class(classes, "form-check-input", prepend=True)
-        elif isinstance(widget, FileInput):
-            classes = add_css_class(classes, "form-control-file", prepend=True)
+        elif isinstance(widget, Select):
+            classes = add_css_class(classes, "form-select", prepend=True)
 
         if self.field.errors:
             if self.error_css_class:

--- a/src/bootstrap5/renderers.py
+++ b/src/bootstrap5/renderers.py
@@ -471,8 +471,8 @@ class FieldRenderer(BaseRenderer):
             label_class = self.horizontal_label_class
             label_class = add_css_class(label_class, "col-form-label")
         label_class = text_value(label_class)
-        if not self.show_label or self.show_label == "sr-only":
-            label_class = add_css_class(label_class, "sr-only")
+        if not self.show_label or self.show_label == "visually-hidden":
+            label_class = add_css_class(label_class, "visually-hidden")
         return label_class
 
     def get_label(self):
@@ -551,4 +551,4 @@ class InlineFieldRenderer(FieldRenderer):
         return self.field_class
 
     def get_label_class(self):
-        return add_css_class(self.label_class, "sr-only")
+        return add_css_class(self.label_class, "visually-hidden")

--- a/src/bootstrap5/renderers.py
+++ b/src/bootstrap5/renderers.py
@@ -552,5 +552,10 @@ class InlineFieldRenderer(FieldRenderer):
     def get_field_class(self):
         return self.field_class
 
+    def get_form_group_class(self):
+        if self.form_group_class == FORM_GROUP_CLASS:
+            self.form_group_class = "col-auto"
+        return super().get_form_group_class()
+
     def get_label_class(self):
         return add_css_class(self.label_class, "visually-hidden")

--- a/src/bootstrap5/renderers.py
+++ b/src/bootstrap5/renderers.py
@@ -471,6 +471,8 @@ class FieldRenderer(BaseRenderer):
             label_class = self.horizontal_label_class
             label_class = add_css_class(label_class, "col-form-label")
         label_class = text_value(label_class)
+        if not label_class:
+            label_class = "form-label"
         if not self.show_label or self.show_label == "visually-hidden":
             label_class = add_css_class(label_class, "visually-hidden")
         return label_class

--- a/src/bootstrap5/templatetags/bootstrap5.py
+++ b/src/bootstrap5/templatetags/bootstrap5.py
@@ -386,7 +386,9 @@ def bootstrap_field(*args, **kwargs):
             CSS class of the ``div`` that wraps the field.
 
         label_class
-            CSS class of the ``label`` element. Will always have ``control-label`` as the last CSS class.
+            CSS class of the ``label`` element.
+
+            :default: ``'form-label'``
 
         form_check_class
             CSS class of the ``div`` element wrapping the label and input when rendering checkboxes and radio buttons.
@@ -434,13 +436,15 @@ def bootstrap_field(*args, **kwargs):
             Text that should be prepended to the form field. Can also be an icon, e.g.
             ``'<span class="glyphicon glyphicon-calendar"></span>'``
 
-            See the `Bootstrap docs <http://getbootstrap.com/components/#input-groups-basic>` for more examples.
+            See the `Bootstrap docs <https://getbootstrap.com/docs/5.0/forms/input-group/#basic-example>`
+            for more examples.
 
         addon_after
             Text that should be appended to the form field. Can also be an icon, e.g.
             ``'<span class="glyphicon glyphicon-calendar"></span>'``
 
-            See the `Bootstrap docs <http://getbootstrap.com/components/#input-groups-basic>` for more examples.
+            See the `Bootstrap docs <https://getbootstrap.com/docs/5.0/forms/input-group/#basic-example>`
+            for more examples.
 
         addon_before_class
             Class used on the span when ``addon_before`` is used.
@@ -511,6 +515,8 @@ def bootstrap_label(*args, **kwargs):
 
         label_class
             The CSS class for the rendered ``<label>``
+
+            :default': ``'form-label'``
 
         label_title
             The value that will be in the ``title`` attribute of the rendered ``<label>``

--- a/src/bootstrap5/templatetags/bootstrap5.py
+++ b/src/bootstrap5/templatetags/bootstrap5.py
@@ -15,6 +15,7 @@ from ..bootstrap import (
 )
 from ..components import render_alert
 from ..forms import (
+    FORM_GROUP_CLASS,
     render_button,
     render_field,
     render_field_and_label,
@@ -379,7 +380,7 @@ def bootstrap_field(*args, **kwargs):
         form_group_class
             CSS class of the ``div`` that wraps the field and label.
 
-            :default: ``'form-group'``
+            :default: ``'mb-3'``
 
         field_class
             CSS class of the ``div`` that wraps the field.
@@ -408,7 +409,7 @@ def bootstrap_field(*args, **kwargs):
             A list of field names that should not be rendered
 
         size
-            Controls the size of the rendered ``div.form-group`` through the use of CSS classes.
+            Controls the size of the rendered ``input.form-control`` through the use of CSS classes.
 
             One of the following values:
 
@@ -471,7 +472,7 @@ def bootstrap_field(*args, **kwargs):
             :default: ``'has-error'``. Can be changed :doc:`settings`
 
         required_css_class
-            CSS class used on the ``div.form-group`` to indicate a field is required
+            CSS class used on the ``div.mb-3`` to indicate a field is required
 
             :default: ``''``. Can be changed :doc:`settings`
 
@@ -680,7 +681,7 @@ class ButtonsNode(template.Node):
             buttons.append(bootstrap_button(reset, "reset"))
         buttons = " ".join(buttons) + self.nodelist.render(context)
         output_kwargs.update({"label": None, "field": buttons})
-        css_class = output_kwargs.pop("form_group_class", "form-group")
+        css_class = output_kwargs.pop("form_group_class", FORM_GROUP_CLASS)
         output = render_form_group(render_field_and_label(**output_kwargs), css_class=css_class)
         if self.asvar:
             context[self.asvar] = output

--- a/src/bootstrap5/templatetags/bootstrap5.py
+++ b/src/bootstrap5/templatetags/bootstrap5.py
@@ -399,7 +399,7 @@ def bootstrap_field(*args, **kwargs):
             Whether the show the label of the field.
 
                 * ``True``
-                * ``False``/``'sr-only'``
+                * ``False``/``'visually-hidden'``
                 * ``'skip'``
 
             :default: ``True``

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -300,8 +300,8 @@ class FieldTest(TestCase):
         # strip out newlines and spaces around newlines
         res = "".join(line.strip() for line in res.split("\n"))
         res = BeautifulSoup(res, "html.parser")
-        form_group = self._select_one_element(res, ".form-group", "RadioSelect should be rendered inside a .form-group")
-        radio = self._select_one_element(form_group, ".radio", "There should be a .radio inside .form-group")
+        form_group = self._select_one_element(res, ".mb-3", "RadioSelect should be rendered inside a .mb-3")
+        radio = self._select_one_element(form_group, ".radio", "There should be a .radio inside .mb-3")
         self.assertIn("radio-success", radio["class"], "The radio select should have the class 'radio-success'")
         elements = radio.find_all("div", class_="form-check")
         self.assertIsNotNone(elements, "Radio should have at least one div with class 'form-check'")
@@ -328,9 +328,9 @@ class FieldTest(TestCase):
         # strip out newlines and spaces around newlines
         res = "".join(line.strip() for line in res.split("\n"))
         res = BeautifulSoup(res, "html.parser")
-        form_group = self._select_one_element(res, ".form-group", "Checkbox should be rendered inside a .form-group.")
+        form_group = self._select_one_element(res, ".mb-3", "Checkbox should be rendered inside a .mb-3.")
         form_check = self._select_one_element(
-            form_group, ".form-check", "There should be a .form-check inside .form-group"
+            form_group, ".form-check", "There should be a .form-check inside .mb-3"
         )
         checkbox = self._select_one_element(form_check, "input", "The checkbox should be inside the .form-check")
         self.assertIn("form-check-input", checkbox["class"], "The checkbox should have the class 'form-check-input'.")
@@ -413,17 +413,17 @@ class FieldTest(TestCase):
             "required, must be placed inside the input-group",
         )
         self._select_one_element(
-            res, ".form-group > .form-text", "The form-text message must be placed inside the form-group"
+            res, ".mb-3 > .form-text", "The form-text message must be placed inside the mb-3"
         )
         self.assertEqual(
-            len(res.select(".form-group > .invalid-feedback")),
+            len(res.select(".mb-3 > .invalid-feedback")),
             0,
-            "The invalid-feedback message must be placed inside the " "input-group and not inside the form-group",
+            "The invalid-feedback message must be placed inside the " "input-group and not inside the mb-3",
         )
         self.assertEqual(
             len(res.select(".input-group > .form-text")),
             0,
-            "The form-text message must be placed inside the form-group and " "not inside the input-group",
+            "The form-text message must be placed inside the mb-3 and " "not inside the input-group",
         )
 
     def test_size(self):

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -600,12 +600,12 @@ class ShowLabelTest(TestCase):
     def test_show_label_false(self):
         form = TestForm()
         res = render_template_with_form("{% bootstrap_form form show_label=False %}", {"form": form})
-        self.assertIn("sr-only", res)
+        self.assertIn("visually-hidden", res)
 
-    def test_show_label_sr_only(self):
+    def test_show_label_visually_hidden(self):
         form = TestForm()
-        res = render_template_with_form("{% bootstrap_form form show_label='sr-only' %}", {"form": form})
-        self.assertIn("sr-only", res)
+        res = render_template_with_form("{% bootstrap_form form show_label='visually-hidden' %}", {"form": form})
+        self.assertIn("visually-hidden", res)
 
     def test_show_label_skip(self):
         form = TestForm()
@@ -616,7 +616,7 @@ class ShowLabelTest(TestCase):
         TestFormSet = formset_factory(TestForm, extra=1)
         test_formset = TestFormSet()
         res = render_template_with_form("{% bootstrap_formset formset show_label=False %}", {"formset": test_formset})
-        self.assertIn("sr-only", res)
+        self.assertIn("visually-hidden", res)
 
 
 class PaginatorTest(TestCase):

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -462,7 +462,7 @@ class FieldTest(TestCase):
 
     def test_label(self):
         res = render_template_with_form('{% bootstrap_label "foobar" label_for="subject" %}')
-        self.assertEqual('<label for="subject">foobar</label>', res)
+        self.assertEqual('<label class="form-label" for="subject">foobar</label>', res)
 
     def test_attributes_consistency(self):
         form = TestForm()

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -346,6 +346,10 @@ class FieldTest(TestCase):
         self.assertIn("form-text", help_text["class"], "The help text should have the class 'form-text'.")
         self.assertIn("text-muted", help_text["class"], "The help text should have the class 'text-muted'.")
 
+    def test_select_class(self):
+        res = render_form_field("select1")
+        self.assertIn('class="form-select"', res)
+
     def test_required_field(self):
         required_css_class = "bootstrap5-req"
         required_field = render_form_field("subject")

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -279,7 +279,7 @@ class FieldTest(TestCase):
         self.assertIn('type="text"', res)
 
         expect = html_39x27(
-            '<label for="id_xss_field">'
+            '<label class="form-label" for="id_xss_field">'
             "XSS&quot; onmouseover=&quot;alert(&#x27;Hello, XSS&#x27;)&quot; foo=&quot;</label>"
         )
         self.assertIn(


### PR DESCRIPTION
Bootstrap 5 removed the `.form-group` class, added the `.form-label` class, and a few other changes to the way forms are constructed. This pull request implements class changes necessary to prevent forms from breaking when rendered with Bootstrap 5.