### PR TITLE
Fixes layout when using the horizontal renderer

### DIFF
--- a/src/bootstrap5/bootstrap.py
+++ b/src/bootstrap5/bootstrap.py
@@ -27,6 +27,7 @@ BOOTSTRAP5_DEFAULTS = {
     "field_renderers": {
         "default": "bootstrap5.renderers.FieldRenderer",
         "inline": "bootstrap5.renderers.InlineFieldRenderer",
+        "horizontal": "bootstrap5.renderers.HorizontalFieldRenderer",
     },
 }
 

--- a/src/bootstrap5/renderers.py
+++ b/src/bootstrap5/renderers.py
@@ -559,3 +559,11 @@ class InlineFieldRenderer(FieldRenderer):
 
     def get_label_class(self):
         return add_css_class(self.label_class, "visually-hidden")
+
+
+class HorizontalFieldRenderer(FieldRenderer):
+    """Horizontal field renderer."""
+
+    # No-op the fix for normal form layout because it breaks the horizontal one.
+    def fix_file_input_label(self, html):
+        return html


### PR DESCRIPTION
This fixes a bug that was introduced back in v2.3.1 with a pull request in the v4 repo.
The additional <br> tag breaks the layout when using horizontal format

Before fix: https://imgur.com/GppCIO6
After fix: https://imgur.com/kew5MF6